### PR TITLE
feat: 调整插件版本号展示位置

### DIFF
--- a/src/pages/sandbox/FeedBack.tsx
+++ b/src/pages/sandbox/FeedBack.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import classnames from 'classnames';
-import { pkg } from '@/config';
+import { pkg, VERSION } from '@/config';
 
 import styles from './FeedBack.module.less';
 
@@ -13,7 +13,7 @@ const FeedBack: React.FC<React.HTMLAttributes<HTMLAnchorElement>> = props => (
     href={pkg.issues}
   >
     <QuestionCircleOutlined className={styles.icon} />
-    {__i18n('问题反馈')}
+    {__i18n('问题反馈')}&nbsp;v{VERSION}
   </a>
 );
 

--- a/src/pages/sandbox/UserInfo.tsx
+++ b/src/pages/sandbox/UserInfo.tsx
@@ -85,23 +85,12 @@ const UserInfo = (props: Props) => {
         ),
       },
       {
-        key: 'current-version',
-        label: (<span>
-          {__i18n('当前版本')}
-          &nbsp;v{VERSION}
-        </span>
-        ),
-      },
-      {
         key: 'logout',
         label: __i18n('退出账户'),
       },
     ].filter(n => {
       if (n.key === 'upgrade-version') {
         return needUpgrade;
-      }
-      if (n.key === 'current-version') {
-        return !needUpgrade;
       }
       return true;
     });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案

![image](https://github.com/yuque/yuque-chrome-extension/assets/6828924/51a8be45-39a1-4b14-a628-e0782ecd6a3d)

### 📝 更新日志

调整插件版本号展示位置
